### PR TITLE
Bump keycloak versions

### DIFF
--- a/.github/actions/presubmit-v2/action.yml
+++ b/.github/actions/presubmit-v2/action.yml
@@ -1,0 +1,120 @@
+name: presubmit
+description: "presubmit"
+inputs:
+  tag:
+    description: |
+      The tags to release images with.
+    required: true
+  archs:
+    description: |
+      The architectures to release images with.
+    default: x86_64 #,aarch64
+runs:
+  using: composite
+  steps:
+    - name: Populate workspace with source only
+      shell: bash
+      run: |
+        shopt -s dotglob && tmp="$(mktemp -d)" && \
+          mv pipelines ${{ inputs.tag }}/* ${tmp}/ && \
+          mv .github ${tmp}/ && \
+          rm -rf ./* && mv ${tmp}/* . && \
+          echo ".github/" >> .melangeignore && tree -a . && \
+          sudo rm -rf /work && sudo mkdir /work
+
+    - uses: chainguard-dev/actions/melange-build@main
+      with:
+        archs: ${{ inputs.archs }}
+        config: keycloak-melange.yaml
+        repository-path: /work/packages
+        pipeline-dir: pipelines
+        sign-with-temporary-key: true
+        signing-key-path: /work/melange.rsa
+
+    - name: Create temp copy of /work directory (used in next step)
+      shell: bash
+      run: |
+        rm -rf .apko-automount && cp -r /work .apko-automount
+
+    - name: Set image name
+      shell: bash
+      id: image
+      run: echo "IMAGE=ghcr.io/${{ github.repository }}:${{ inputs.tag }}-smoketest" >> $GITHUB_OUTPUT
+
+    - name: Generate snapshot date
+      id: snapshot-date
+      run: |
+        echo ::set-output name=date::$(date -u +%Y%m%d)
+        echo ::set-output name=epoch::$(date -u +%s)
+      shell: bash
+
+    - uses: chainguard-images/actions/apko-build@main
+      with:
+        config: apko.yaml
+        tag: ${{ steps.image.outputs.IMAGE }}
+        keyring-append: /work/melange.rsa.pub
+        archs: ${{ inputs.archs }}
+        automount-src: .apko-automount/.
+        automount-dest: /work
+        source-date-epoch: ${{ steps.snapshot-date.outputs.epoch }}
+
+    - name: Load image from apko-produced tarball
+      shell: bash
+      run: |
+        docker load < output.tar
+
+    - name: Smoke test
+      shell: bash
+      run: |
+        set -e
+
+        docker run -d --rm -p 9000:9000 -p 8080:8080 \
+          -e KEYCLOAK_DATABASE_VENDOR=dev-mem \
+          -e KEYCLOAK_ENABLE_HEALTH_ENDPOINTS=true \
+          -e KC_BOOTSTRAP_ADMIN_PASSWORD=keycloak123 \
+          --name smoketest "${{ steps.image.outputs.IMAGE }}-amd64"
+
+        trap "docker rm -f smoketest" EXIT
+        sleep 30 # Give server a few seconds to come up
+
+        curl -v --max-time 10 --fail http://localhost:9000/health
+
+    - name: Scan image
+      uses: anchore/scan-action@v7
+      id: scan
+      with:
+        image: "${{ steps.image.outputs.IMAGE }}-amd64"
+        fail-build: false
+        output-format: json
+
+    - name: Generate Markdown report
+      shell: bash
+      run: |
+        jq -r '
+          def sanitize(s): if s then s|tostring|gsub("\\|"; "\\\\|") else "" end;
+          def vuln_link(v):
+            if v.id|startswith("CVE-") then
+              "[" + v.id + "](https://nvd.nist.gov/vuln/detail/" + v.id + ")"
+            elif v.id|startswith("GHSA-") then
+              "[" + v.id + "](https://github.com/advisories/" + v.id + ")"
+            else
+              v.id
+            end;
+          def row(m):
+            "| " + sanitize(m.artifact.name)
+            + " | " + sanitize(m.artifact.version)
+            + " | " + sanitize(m.artifact.type)
+            + " | " + vuln_link(m.vulnerability)
+            + " | " + sanitize(m.vulnerability.severity)
+            + " |";
+          "# 🔍 Anchore/Grype scan results ${{ inputs.tag }}\n\n" +
+          "| NAME | INSTALLED | TYPE | VULNERABILITY | SEVERITY |\n" +
+          "|---|---|---|---|---|\n" +
+          ( .matches | map(row(.)) | join("\n") )
+        ' "${{ steps.scan.outputs.json }}" > scan_results.md
+
+    - name: Comment or update PR
+      uses: thollander/actions-comment-pull-request@v3
+      with:
+        file-path: scan_results.md
+        comment-tag: ${{ inputs.tag }}

--- a/.github/actions/release-v2/action.yml
+++ b/.github/actions/release-v2/action.yml
@@ -1,0 +1,114 @@
+name: release
+description: "release"
+inputs:
+  tag:
+    description: |
+      The tags to release images with.
+    required: true
+  extraTags:
+    description: |
+      The extra tags to release images with.
+    required: false
+  archs:
+    description: |
+      The architectures to release images with.
+    default: x86_64 #,aarch64
+runs:
+  using: composite
+  steps:
+    - name: Populate workspace with source only
+      shell: bash
+      run: |
+        shopt -s dotglob && tmp="$(mktemp -d)" && \
+          mv melange.rsa.pub pipelines ${{ inputs.tag }}/* ${tmp}/ && \
+          mv .github ${tmp}/ && \
+          rm -rf ./* && mv ${tmp}/* . && \
+          echo ".github/" >> .melangeignore && tree -a . && \
+          sudo rm -rf /work && sudo mkdir /work
+
+    - name: Write melange key
+      shell: bash
+      run: |
+        printf '%s' "$MELANGE_PRIVATE_KEY" > melange.rsa
+        chmod 0600 melange.rsa
+
+    - uses: chainguard-dev/actions/melange-build@main
+      with:
+        archs: ${{ inputs.archs }}
+        multi-config: keycloak-melange.yaml
+        sign-with-own-key: true
+        signing-key-path: melange.rsa
+        repository-path: /work/packages
+        pipeline-dir: pipelines
+
+    - name: Create temp copy of /work directory (used in next step)
+      shell: bash
+      run: |
+        rm -rf .apko-automount && cp -r /work .apko-automount
+
+    - name: Set image name
+      shell: bash
+      id: image
+      run: |
+        # Start with the main tag
+        ALL_TAGS="latest-${{ inputs.tag }}"
+
+        # Append extraTags if provided
+        if [ -n "${{ inputs.extraTags }}" ]; then
+          ALL_TAGS="${ALL_TAGS},${{ inputs.extraTags }}"
+        fi
+
+        REPO="ghcr.io/${{ github.repository }}"
+        IMAGE_TAGS=""
+
+        IFS=',' read -ra TAG_ARRAY <<< "$ALL_TAGS"
+        for tag in "${TAG_ARRAY[@]}"; do
+          tag=$(echo "$tag" | xargs)  # Trim whitespace
+          IMAGE_TAGS="${IMAGE_TAGS} ${REPO}:${tag}"
+        done
+
+        IMAGE_TAGS=$(echo "$IMAGE_TAGS" | xargs)  # Trim leading/trailing whitespace
+        echo "IMAGE=${IMAGE_TAGS}" >> $GITHUB_OUTPUT
+
+    - name: Generate snapshot date
+      id: snapshot-date
+      run: |
+        echo ::set-output name=date::$(date -u +%Y%m%d)
+        echo ::set-output name=epoch::$(date -u +%s)
+      shell: bash
+
+    - uses: chainguard-images/actions/apko-publish@main
+      with:
+        archs: ${{ inputs.archs }}
+        config: apko.yaml
+        tag: ${{ steps.image.outputs.IMAGE }}
+        keyring-append: melange.rsa.pub
+        automount-src: .apko-automount/.
+        automount-dest: /work
+        source-date-epoch: ${{ steps.snapshot-date.outputs.epoch }}
+
+    # - uses: sigstore/cosign-installer@main
+
+    - name: Smoke test
+      shell: bash
+      run: |
+        set -e
+
+        # Use the first tag for smoke testing
+        refs="${{ steps.image.outputs.IMAGE }}"
+        ref=$(echo "$refs" | awk '{print $1}')
+
+        docker pull "${ref}"
+
+        # cosign verify "${ref}" --key melange.rsa.pub
+
+        docker run -d --rm -p 9000:9000 -p 8080:8080 \
+          -e KEYCLOAK_DATABASE_VENDOR=dev-mem \
+          -e KEYCLOAK_ENABLE_HEALTH_ENDPOINTS=true \
+          -e KC_BOOTSTRAP_ADMIN_PASSWORD=keycloak123 \
+          --name smoketest "${ref}"
+
+        trap "docker rm -f smoketest" EXIT
+        sleep 30 # Give server a few seconds to come up
+
+        curl -v --max-time 10 --fail http://localhost:9000/health

--- a/.github/workflows/26.5-release.yaml
+++ b/.github/workflows/26.5-release.yaml
@@ -24,9 +24,3 @@ jobs:
           MELANGE_PRIVATE_KEY: ${{ secrets.MELANGE_PRIVATE_KEY }}
         with:
           tag: "26.5"
-          extraTags: "latest"
-      - uses: actions/delete-package-versions@v5
-        with: 
-          package-name: 'keycloak-bitnami-image'
-          package-type: 'container'
-          min-versions-to-keep: 20

--- a/.github/workflows/26.6-presubmit.yml
+++ b/.github/workflows/26.6-presubmit.yml
@@ -1,0 +1,22 @@
+name: "26.6-presubmit"
+on:
+  pull_request:
+    paths:
+      - .github/actions/presubmit/action-v2.yml
+      - .github/workflows/26.6-presubmit.yml
+      - pipelines/bitnami/compat.yaml
+      - 26.6/**
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  build:
+    name: Verify image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/presubmit-v2
+        env:
+          MELANGE_PRIVATE_KEY: ${{ secrets.MELANGE_PRIVATE_KEY }}
+        with:
+          tag: "26.6"

--- a/.github/workflows/26.6-release.yaml
+++ b/.github/workflows/26.6-release.yaml
@@ -1,0 +1,32 @@
+name: 26.6-release
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/actions/release/action-v2.yml
+      - .github/workflows/26.6-release.yml
+      - pipelines/bitnami/compat.yaml
+      - 26.6/**
+  workflow_dispatch:
+jobs:
+  build:
+    name: Release image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/release-v2
+        env:
+          MELANGE_PRIVATE_KEY: ${{ secrets.MELANGE_PRIVATE_KEY }}
+        with:
+          tag: "26.6"
+          extraTags: "latest"
+      - uses: actions/delete-package-versions@v5
+        with: 
+          package-name: 'keycloak-bitnami-image'
+          package-type: 'container'
+          min-versions-to-keep: 20

--- a/26.2/keycloak-melange.yaml
+++ b/26.2/keycloak-melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-bitnami
   version: 26.2.15
-  epoch: 0
+  epoch: 1
   description: "Open Source Identity and Access Management For Modern Applications and Services"
   copyright:
     - paths:

--- a/26.5/keycloak-melange.yaml
+++ b/26.5/keycloak-melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-bitnami
   version: 26.5.7
-  epoch: 0
+  epoch: 1
   description: "Open Source Identity and Access Management For Modern Applications and Services"
   copyright:
     - paths:
@@ -96,7 +96,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: keycloak
-          commit: 6279eaa75f3a083a7c1e60034f7f85e08c74eab8
+          commit: 5427a07cd20b50d449307e86ac52826874c95c15
           version-path: ${{vars.major-version}}/debian-12
       - runs: |
           mkdir -p ${{targets.contextdir}}/bitnami/keycloak

--- a/26.6/apko.yaml
+++ b/26.6/apko.yaml
@@ -1,0 +1,46 @@
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    - '@local /work/packages'
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - busybox
+    - keycloak-bitnami@local
+    - keycloak-bitnami-compat@local
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: "65532"
+
+paths:
+  - path: /opt/bitnami
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+    recursive: true
+
+  - path: /bitnami
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+    recursive: true
+
+environment:
+    LANG: en_US.UTF-8
+    JAVA_HOME: /usr/lib/jvm/java-25-openjdk
+    APP_VERSION: 26.6.0
+    BITNAMI_APP_NAME: keycloak
+    PATH: /opt/bitnami/common/bin:/usr/lib/jvm/java-25-openjdk:/opt/bitnami/keycloak/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+entrypoint:
+  command: /opt/bitnami/scripts/keycloak/entrypoint.sh
+cmd: /opt/bitnami/scripts/keycloak/run.sh

--- a/26.6/keycloak-melange.yaml
+++ b/26.6/keycloak-melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-bitnami
-  version: 26.4.11
-  epoch: 1
+  version: 26.6.0
+  epoch: 0
   description: "Open Source Identity and Access Management For Modern Applications and Services"
   copyright:
     - paths:
@@ -12,7 +12,7 @@ package:
     runtime:
       - bash
       - merged-usrsbin
-      - openjdk-21-default-jdk
+      - openjdk-25-default-jdk
       - wolfi-baselayout
   checks:
     disabled:
@@ -39,36 +39,30 @@ environment:
       - busybox
       - ca-certificates-bundle
       - gcc-13-default
-      - openjdk-21-default-jdk
+      - nodejs
+      - openjdk-25-default-jdk
+      - pnpm
       - wolfi-base
       - wolfi-baselayout
   environment:
     LANG: en_US.UTF-8
-    JAVA_HOME: /usr/lib/jvm/java-21-openjdk
+    JAVA_HOME: /usr/lib/jvm/java-25-openjdk
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/keycloak/keycloak
       tag: ${{package.version}}
-      expected-commit: 6372cc228741e2a844493eabb1eb5f7fd9d15974
+      expected-commit: 0526b94f0ddf166a210e39fd69d897ab4bb14431
 
-  - uses: patch
-    with:
-      patches: pom.patch
+  # - uses: patch
+  #   with:
+  #     patches: pom.patch
 
   - uses: maven/pombump
 
   - runs: |
-      gcc napi-static-assert.c -o /tmp/preload.so -fPIC -shared -ldl
-
-  - runs: |
-      # Build keycloak-server. Depends on `keycloak-js-adapter-jar`.
-      # Gross hack to work around broken NAPI ast-grep module that has
-      # undefined symbol: static_assert
-      export LD_PRELOAD=/tmp/preload.so
       ./mvnw clean install --errors -DskipTests -DskipTestsuite -DskipExamples -q -DskipProtoLock=true
-      unset LD_PRELOAD
 
       mkdir -p ${{targets.destdir}}/opt/bitnami
       unzip -d ${{targets.destdir}}/opt/bitnami quarkus/dist/target/keycloak-*.zip
@@ -85,7 +79,7 @@ subpackages:
         - libaio
         - merged-usrsbin
         - net-tools
-        - openjdk-21-default-jdk
+        - openjdk-25-default-jdk
         - posix-libc-utils
         - procps
         - su-exec
@@ -96,7 +90,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: keycloak
-          commit: 3f954a8ceaf9c63ec0c8ca27d16d8c14889ec5a9
+          commit: 4a8bdf52699e3e5a0b2991648dc07670e7029d61
           version-path: ${{vars.major-version}}/debian-12
       - runs: |
           mkdir -p ${{targets.contextdir}}/bitnami/keycloak
@@ -113,10 +107,10 @@ subpackages:
           sed -i 's/hostname --fqdn/hostname -f/g' ${{targets.contextdir}}/opt/bitnami/scripts/keycloak-env.sh
 
           # Fix the JAVA_HOME Path in the script
-          sed -i 's/JAVA_HOME="\/opt\/bitnami\/java"/JAVA_HOME="\/usr\/lib\/jvm\/java-21-openjdk"/g' ${{targets.contextdir}}/opt/bitnami/scripts/keycloak-env.sh
+          sed -i 's/JAVA_HOME="\/opt\/bitnami\/java"/JAVA_HOME="\/usr\/lib\/jvm\/java-25-openjdk"/g' ${{targets.contextdir}}/opt/bitnami/scripts/keycloak-env.sh
 
           # Change the path for java security folder in the script
-          sed -i 's/\/opt\/bitnami\/java\/lib\/security/\/usr\/lib\/jvm\/java-21-openjdk\/conf\/security/g' ${{targets.contextdir}}/opt/bitnami/scripts/java/postunpack.sh
+          sed -i 's/\/opt\/bitnami\/java\/lib\/security/\/usr\/lib\/jvm\/java-25-openjdk\/conf\/security/g' ${{targets.contextdir}}/opt/bitnami/scripts/java/postunpack.sh
 
           # The `--userspec`` flag belongs to GNU's chroot, whereas we are use BusyBox's. As a workaround, use `su-exec` instead.
           sed -i 's|exec chroot --userspec="$userspec" /|exec chroot / su-exec "$userspec"|' ${{targets.contextdir}}/opt/bitnami/scripts/libos.sh

--- a/26.6/napi-static-assert.c
+++ b/26.6/napi-static-assert.c
@@ -1,0 +1,3 @@
+int static_assert(void *f()) {
+        return 0;
+}

--- a/26.6/pom.patch
+++ b/26.6/pom.patch
@@ -1,0 +1,21 @@
+diff --git a/pom.xml b/pom.xml
+index 03a23ebaab..d89ce8e367 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -312,6 +312,16 @@
+     <dependencyManagement>
+
+         <dependencies>
++            <dependency>
++                <groupId>io.vertx</groupId>
++                <artifactId>vertx-core</artifactId>
++                <version>4.5.24</version>
++            </dependency>
++            <dependency>
++                <groupId>com.fasterxml.jackson.core</groupId>
++                <artifactId>jackson-core</artifactId>
++                <version>2.21.1</version>
++            </dependency>
+             <dependency>
+                 <groupId>org.infinispan</groupId>
+                 <artifactId>infinispan-bom</artifactId>

--- a/26.6/pombump-deps.yaml
+++ b/26.6/pombump-deps.yaml
@@ -1,0 +1,7 @@
+patches:
+  - groupId: io.netty
+    artifactId: netty-codec-http2
+    version: 4.1.132.Final
+  - groupId: io.netty
+    artifactId: netty-codec-http
+    version: 4.1.132.Final

--- a/26.6/pombump-properties.yaml
+++ b/26.6/pombump-properties.yaml
@@ -1,0 +1,3 @@
+# properties:
+#   - property: angus.mail.version
+#     value: "2.0.4"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This project aims to build a secure and up-to-date container image for Bitnami's
 
 | Image Tag               | Keycloak Version  | Description                                 |
 |------------------------ |-------------------|---------------------------------------------|
-| **latest, latest-26.5** | **26.5.7**        | Latest stable release of Keycloak           |
+| **latest, latest-26.6** | **26.6.0**        | Latest stable release of Keycloak           |
+| latest-26.5             | 26.5.7            | Latest release within Keycloak version 26.5 |
 | latest-26.4             | 26.4.11           | Latest release within Keycloak version 26.4 |
 | latest-26.2             | 26.2.15           | Latest release within Keycloak version 26.2 |
 
@@ -57,18 +58,10 @@ To build the container image using Melange and Apko, follow these steps:
 docker run --rm -v "$(pwd)":/work cgr.dev/chainguard/melange keygen
 ```
 
-- Build the package for Keycloak metrics SPI:
-
-```bash
-KEYCLOAK_VERSION=26.4 docker run --privileged --rm -v "$(pwd)":/work -w /work \
-  cgr.dev/chainguard/melange build $KEYCLOAK_VERSION/keycloak-metrics-spi-melange.yaml \
-  --signing-key melange.rsa
-```
-
 - Build the package for Keycloak:
 
 ```bash
-KEYCLOAK_VERSION=26.4 docker run --privileged --rm -v "$(pwd)":/work -w /work \
+KEYCLOAK_VERSION=26.6 docker run --privileged --rm -v "$(pwd)":/work -w /work \
   cgr.dev/chainguard/melange build $KEYCLOAK_VERSION/keycloak-melange.yaml \
   --signing-key melange.rsa --pipeline-dir pipelines
 ```
@@ -76,7 +69,7 @@ KEYCLOAK_VERSION=26.4 docker run --privileged --rm -v "$(pwd)":/work -w /work \
 - Build the container image:
 
 ```bash
-KEYCLOAK_VERSION=26.4 docker run --rm -v "$(pwd)":/work -w /work cgr.dev/chainguard/apko build $KEYCLOAK_VERSION/apko.yaml \
+KEYCLOAK_VERSION=26.6 docker run --rm -v "$(pwd)":/work -w /work cgr.dev/chainguard/apko build $KEYCLOAK_VERSION/apko.yaml \
   keycloak-bitnami-image:latest keycloak-bitnami-image-latest.tar \
   --keyring-append melange.rsa.pub
 ```


### PR DESCRIPTION
From 26.6.0 SPI will be removed. Since it hasn't been updated and it is mostly highly covered by the core feature